### PR TITLE
docs: fix missing space in axis configuration text

### DIFF
--- a/notebooks/08-Configuration.ipynb
+++ b/notebooks/08-Configuration.ipynb
@@ -1026,7 +1026,7 @@
    "source": [
     "## Example 3: Axis Properties\n",
     "\n",
-    "If you would like to set the properties of the axes, including grid lines, you can use the encodings'``axis`` argument."
+    "If you would like to set the properties of the axes, including grid lines, you can use the encodings' ``axis`` argument."
    ]
   },
   {


### PR DESCRIPTION
Fixes #14

Changes:
- `encodings'``axis`` argument` -> `encodings' ``axis`` argument` in `notebooks/08-Configuration.ipynb` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
